### PR TITLE
Fetch events from server on time travel UI

### DIFF
--- a/time-travel/DemoWeb/Program.cs
+++ b/time-travel/DemoWeb/Program.cs
@@ -106,6 +106,10 @@ app.MapGet("/api/events", async (long checkpoint, DateTimeOffset date,
 // Start the web server //
 // -------------------- //
 
+app.UseStaticFiles();
+
+app.MapFallbackToFile("index.html"); // Serve wwwroot/index.html which is built by Vite
+
 var port = Environment.GetEnvironmentVariable("PORT") ?? "3000";
 
 app.Run($"http://0.0.0.0:{port}");

--- a/time-travel/DemoWeb/client/app/ReportReadModel.ts
+++ b/time-travel/DemoWeb/client/app/ReportReadModel.ts
@@ -9,23 +9,16 @@ export interface ReportReadModel {
 }
 
 export interface SalesReport {
-  categorySalesReports: Record<Category, CategorySalesReport>;
+  categories: Record<Category, CategorySalesReport>;
 }
 
 export interface CategorySalesReport {
-  regionSalesReports: Record<Region, RegionSalesReport>;
+  regions: Record<Region, RegionSalesReport>;
 }
 
 export interface RegionSalesReport {
   dailySales: number;
-  targetSales: number;
+  monthEndSalesTarget: number;
   totalMonthlySales: number;
   targetHitRate: number;
-}
-
-export enum SalesRegion {
-  Asia = "Asia",
-  Europe = "Europe",
-  NorthAmerica = "North America",
-  MiddleEast = "Middle East",
 }

--- a/time-travel/DemoWeb/client/app/SalesDashboard.module.css
+++ b/time-travel/DemoWeb/client/app/SalesDashboard.module.css
@@ -110,6 +110,10 @@
         width: 10%;
       }
 
+      .selectedCell {
+        background-color: #e6f1ff;
+      }
+
       .salesProgressBar {
         display: flex;
         align-items: center;
@@ -192,5 +196,15 @@
         }
       }
     }
+  }
+}
+
+.buttonLink {
+  color: var(--color-highlight-dark);
+  text-decoration: underline;
+  cursor: pointer;
+
+  &:active {
+    color: #0000ff;
   }
 }

--- a/time-travel/DemoWeb/client/app/SalesDashboard.module.css
+++ b/time-travel/DemoWeb/client/app/SalesDashboard.module.css
@@ -74,7 +74,8 @@
       border-spacing: 0;
       border: 1px solid var(--light-grey);
 
-      .arrowSalesIncreased, .arrowSalesDecreased {
+      .arrowSalesIncreased,
+      .arrowSalesDecreased {
         margin-left: 0.25rem;
         font-weight: bold;
       }
@@ -92,7 +93,8 @@
         color: var(--text-color-highlight);
       }
 
-      td, th {
+      td,
+      th {
         text-align: center;
         padding: 0.5rem;
         margin: 0;
@@ -106,7 +108,8 @@
         border: 1px solid var(--light-grey);
       }
 
-      .dailySalesCol, .targetSalesCol {
+      .dailySalesCol,
+      .targetSalesCol {
         width: 10%;
       }
 
@@ -114,44 +117,50 @@
         background-color: #e6f1ff;
       }
 
-      .salesProgressBar {
-        display: flex;
-        align-items: center;
-        justify-content: start;
-        color: #fff;
-        background-color: #9d9d9d;
-        height: 1.5rem;
-        width: 80%;
-        border-radius: 2px;
-        font-weight: lighter;
-        margin: 0 auto;
-        position: relative;
+      .salesProgressBarCell {
+        cursor: pointer;
 
-        .progressBarSuccess, .progressBarFailure {
-          height: 100%;
+        .salesProgressBar {
+          display: flex;
+          align-items: center;
+          justify-content: start;
+          color: #fff;
+          background-color: #9d9d9d;
+          height: 1.5rem;
+          width: 80%;
           border-radius: 2px;
-        }
+          font-weight: lighter;
+          margin: 0 auto;
+          position: relative;
 
-        .progressBarLabel {
-          position: absolute;
-          top: 50%;
-          left: 50%;
-          transform: translate(-50%, -50%);
-          width: 100%;
-        }
+          .progressBarSuccess,
+          .progressBarFailure {
+            height: 100%;
+            border-radius: 2px;
+          }
 
-        .progressBarSuccess {
-          background-color: #28a745;
-        }
+          .progressBarLabel {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            width: 100%;
+          }
 
-        .progressBarFailure {
-          background-color: #d34d5c;
+          .progressBarSuccess {
+            background-color: #28a745;
+          }
+
+          .progressBarFailure {
+            background-color: #d34d5c;
+          }
         }
       }
     }
   }
 
-  .salesData, .eventStream {
+  .salesData,
+  .eventStream {
     padding: 1rem;
     background-color: #fff;
     border: 1px solid #fff;

--- a/time-travel/DemoWeb/client/app/SalesDashboard.module.css
+++ b/time-travel/DemoWeb/client/app/SalesDashboard.module.css
@@ -106,21 +106,34 @@
         border: 1px solid var(--light-grey);
       }
 
+      .dailySalesCol, .targetSalesCol {
+        width: 10%;
+      }
+
       .salesProgressBar {
         display: flex;
         align-items: center;
         justify-content: start;
         color: #fff;
-        background-color: var(--light-grey);
+        background-color: #9d9d9d;
         height: 1.5rem;
         width: 80%;
         border-radius: 2px;
         font-weight: lighter;
         margin: 0 auto;
+        position: relative;
 
         .progressBarSuccess, .progressBarFailure {
           height: 100%;
           border-radius: 2px;
+        }
+
+        .progressBarLabel {
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          transform: translate(-50%, -50%);
+          width: 100%;
         }
 
         .progressBarSuccess {

--- a/time-travel/DemoWeb/client/app/SalesDashboard.module.css
+++ b/time-travel/DemoWeb/client/app/SalesDashboard.module.css
@@ -199,6 +199,15 @@
   }
 }
 
+.errorAlert {
+  background-color: #ffebed;
+  color: #bd2d3d;
+  margin: 3rem auto;
+  padding: 1rem;
+  border-radius: 4px;
+  border: 1px #bd2d3d solid;
+}
+
 .buttonLink {
   color: var(--color-highlight-dark);
   text-decoration: underline;

--- a/time-travel/DemoWeb/client/app/SalesDashboard.module.css
+++ b/time-travel/DemoWeb/client/app/SalesDashboard.module.css
@@ -175,19 +175,21 @@
       border-radius: 4px;
       padding: 0.5rem;
       background-color: var(--background-color-grey);
+      font-family: monospace;
 
       &:not(:nth-child(2)) {
         margin-top: 1rem;
       }
 
-      .eventType {
+      .eventCardHeader {
         font-weight: bold;
-        margin-bottom: 0.25rem;
       }
 
-      .eventTimestamp {
-        color: #666;
-        font-size: 0.8rem;
+      .eventCardPair {
+        .eventCardPairLabel {
+          text-transform: uppercase;
+          font-weight: bold;
+        }
       }
     }
   }

--- a/time-travel/DemoWeb/client/app/SalesDashboard.tsx
+++ b/time-travel/DemoWeb/client/app/SalesDashboard.tsx
@@ -13,7 +13,7 @@ import SalesEvent from "./SalesEvent"
 const READ_MODEL_ENDPOINT = "/api/sales-data"
 
 const SalesDashboard = () => {
-  const [reportReadModel, setReportReadModel] = useState<ReportReadModel>([])
+  const [reportReadModel, setReportReadModel] = useState<ReportReadModel | null>(null)
   const [selectedReportDate, setSelectedReportDate] = useState<string | null>(
     null,
   )
@@ -199,21 +199,21 @@ const SalesTable = ({ salesReport, previousReport }: SalesTableProps) => {
         <tr>
           <th scope="col">Category</th>
           <th scope="col">Region</th>
-          <th scope="col">Daily Sales</th>
-          <th scope="col">Target Sales</th>
+          <th className={styles.dailySalesCol} scope="col">Daily Sales</th>
+          <th className={styles.targetSalesCol} scope="col">Target Sales</th>
           <th scope="col">Total Monthly Sales</th>
         </tr>
       </thead>
       <tbody>
         {_.map(
-          salesReport.categorySalesReports,
+          salesReport.categories,
           (categorySalesReport: CategorySalesReport, category: Category) => (
             <SalesCategory
               key={category}
               category={category}
               categorySalesReport={categorySalesReport}
               previousCategorySalesReport={
-                previousReport?.categorySalesReports[category]
+                previousReport?.categories[category]
               }
             />
           ),
@@ -234,11 +234,11 @@ const SalesCategory = ({
   categorySalesReport,
   previousCategorySalesReport,
 }: SalesCategoryProps) => {
-  const { regionSalesReports } = categorySalesReport
-  const regionPairs = Object.entries(regionSalesReports)
+  const { regions } = categorySalesReport
+  const regionPairs = Object.entries(regions)
 
   return regionPairs.map(([region, regionalSalesData], i) => {
-    const { dailySales, targetSales, totalMonthlySales } = regionalSalesData
+    const { dailySales, monthEndSalesTarget, totalMonthlySales } = regionalSalesData
     const previousRegionalSales =
       previousCategorySalesReport?.[region as SalesRegion]
 
@@ -264,15 +264,15 @@ const SalesCategory = ({
           </td>
         )}
         <td>{region}</td>
-        <td>
+        <td className={styles.dailySalesCol}>
           <span>${dailySales}</span>
           <span className={arrowClassName}>{arrow}</span>
         </td>
-        <td>${targetSales}</td>
+        <td className={styles.targetSalesCol}>${monthEndSalesTarget}</td>
         <td>
           <SalesProgressBar
             totalMonthlySales={totalMonthlySales}
-            targetSales={targetSales}
+            targetSales={monthEndSalesTarget}
           />
         </td>
       </tr>
@@ -295,9 +295,8 @@ const SalesProgressBar = ({
 
   return (
     <div className={styles.salesProgressBar}>
-      <div className={innerClassName} style={{ width: `${percentage}%` }}>
-        ${totalMonthlySales} ({percentage.toFixed(2)}%)
-      </div>
+      <div className={innerClassName} style={{ width: `${percentage}%` }}/>
+      <span className={styles.progressBarLabel}>${totalMonthlySales} ({percentage.toFixed(2)}%)</span>
     </div>
   )
 }

--- a/time-travel/DemoWeb/client/app/SalesDashboard.tsx
+++ b/time-travel/DemoWeb/client/app/SalesDashboard.tsx
@@ -11,6 +11,7 @@ import SalesEvent from "./SalesEvent"
 
 const READ_MODEL_ENDPOINT = "/api/sales-data"
 const EVENTS_ENDPOINT = "/api/events"
+const EVENT_STREAM = "$et-order-placed"
 
 enum SalesFigureType {
   DailySales = 0,
@@ -432,20 +433,40 @@ const EventStream = ({ eventQueryParams }: EventStreamProps) => {
 }
 
 const EventCard = ({ event }: { event: SalesEvent }) => {
-  const { category, region, eventNumber, at } = event
+  const { category, region, eventNumber, at, totalSalesForCategory } = event
+
+  const eventLink = `http://${window.location.hostname}:2113/web/index.html#/streams/$et-order-placed/${eventNumber}`
 
   return (
     <div className={styles.eventCard}>
-      <span className={styles.eventType}>{eventNumber}</span>
-      <span className={styles.eventTimestamp}>
-        {new Date(at).toLocaleString()}
+      <a className={styles.eventCardHeader} href={eventLink} target="_blank">
+        Event #{eventNumber} in $et-order-placed
+      </a>
+      <span>
+        <EventCardPair label="Date" value={new Date(at).toLocaleString()} />
+        &nbsp;|&nbsp;
+        <EventCardPair label="Region" value={region} />
       </span>
-      {/*{eventDataPairs.map(([key, value]) => (*/}
-      {/*  <span className={styles.eventField}>*/}
-      {/*    {_.startCase(key)}: {value}*/}
-      {/*  </span>*/}
-      {/*))}*/}
+      <EventCardPair label="Category" value={category} />
+      <EventCardPair
+        label="Total Sales"
+        value={`USD ${totalSalesForCategory}`}
+      />
     </div>
+  )
+}
+
+interface EventCardPairProps {
+  label: string
+  value: string
+}
+
+const EventCardPair = ({ label, value }: EventCardPairProps) => {
+  return (
+    <span className={styles.eventCardPair}>
+      <span className={styles.eventCardPairLabel}>{label}: </span>
+      <span className={styles.eventCardPairValue}>{value}</span>
+    </span>
   )
 }
 

--- a/time-travel/DemoWeb/client/app/SalesDashboard.tsx
+++ b/time-travel/DemoWeb/client/app/SalesDashboard.tsx
@@ -373,22 +373,16 @@ const SalesCategory = ({
           </span>
           <span className={arrowClassName}>{arrow}</span>
         </td>
+        <td className={styles.targetSalesCol}>${monthEndSalesTarget}</td>
         <td
-          className={classNames(styles.targetSalesCol, {
+          className={classNames(styles.salesProgressBarCell, {
             [styles.selectedCell]:
               categoryAndRegionSelected &&
               selectedTableCell?.salesFigureType ===
                 SalesFigureType.TotalMonthlySales,
           })}
+          onClick={getOnSalesFigureClick(SalesFigureType.TotalMonthlySales)}
         >
-          <span
-            className={styles.buttonLink}
-            onClick={getOnSalesFigureClick(SalesFigureType.TotalMonthlySales)}
-          >
-            ${monthEndSalesTarget}
-          </span>
-        </td>
-        <td>
           <SalesProgressBar
             totalMonthlySales={totalMonthlySales}
             targetSales={monthEndSalesTarget}

--- a/time-travel/DemoWeb/client/app/SalesDashboard.tsx
+++ b/time-travel/DemoWeb/client/app/SalesDashboard.tsx
@@ -23,11 +23,15 @@ enum SalesFigureType {
 const SalesDashboard = () => {
   const [reportReadModel, setReportReadModel] =
     useState<ReportReadModel | null>(null)
+
   const [selectedReportDate, setSelectedReportDate] = useState<string | null>(
     null,
   )
+
   const [selectedTableCell, setSelectedTableCell] =
     useState<SelectedTableCell | null>(null)
+
+  const [error, setError] = useState<string | null>(null)
 
   const previousReportDate = selectedReportDate
     ? getPreviousDay(selectedReportDate)
@@ -44,6 +48,7 @@ const SalesDashboard = () => {
       : null
 
   useEffect(() => {
+    setError(null)
     fetch(READ_MODEL_ENDPOINT, {
       method: "GET",
       headers: {
@@ -56,14 +61,17 @@ const SalesDashboard = () => {
         const earliestReportDate = getEarliestReportDate(data)
         if (earliestReportDate) setSelectedReportDate(earliestReportDate)
       })
-      .catch((error) =>
-        console.error("Error fetching sales data from the server", error),
-      )
+      .catch((e) => {
+        const errorMessage = "Error fetching sales data from the server"
+        console.error(errorMessage, e)
+        setError(`${errorMessage}: ${e.message}`)
+      })
   }, [])
 
   return (
     <div className={styles.pageRoot}>
       <Header />
+      {error && <ErrorAlert error={error} />}
       {!!selectedReport && !!reportReadModel && (
         <>
           <TimeSliderSection
@@ -84,6 +92,10 @@ const SalesDashboard = () => {
     </div>
   )
 }
+
+const ErrorAlert = ({ error }: { error: string }) => (
+  <div className={styles.errorAlert}>{error}</div>
+)
 
 const toDateString = (date: Date) => date.toISOString().split("T")[0]
 

--- a/time-travel/DemoWeb/client/app/SalesDashboard.tsx
+++ b/time-travel/DemoWeb/client/app/SalesDashboard.tsx
@@ -58,8 +58,9 @@ const SalesDashboard = () => {
       .then((response) => response.json())
       .then((data: ReportReadModel) => {
         setReportReadModel(data)
-        const earliestReportDate = getEarliestReportDate(data)
-        if (earliestReportDate) setSelectedReportDate(earliestReportDate)
+        const latestReportDate = getLatestReportDate(data)
+
+        if (latestReportDate) setSelectedReportDate(latestReportDate)
       })
       .catch((e) => {
         const errorMessage = "Error fetching sales data from the server"
@@ -105,12 +106,12 @@ const getPreviousDay = (dateString: string): string => {
   return toDateString(date)
 }
 
-const getEarliestReportDate = (
+const getLatestReportDate = (
   readModel: ReportReadModel,
 ): string | undefined => {
   const dates = Object.keys(readModel.salesReports)
 
-  return _.minBy(dates, (date) => new Date(date).getTime())
+  return _.maxBy(dates, (date) => new Date(date).getTime())
 }
 
 const Header = () => (
@@ -163,6 +164,8 @@ const TimeSlider = ({
   const firstReportDate = orderedDates[0]
   const lastReportDate = orderedDates[orderedDates.length - 1]
 
+  const maxValue = orderedDates.length - 1
+
   return (
     <div className={styles.timeSliderContainer}>
       <span className={styles.timeSliderLabel}>{firstReportDate}</span>
@@ -170,9 +173,9 @@ const TimeSlider = ({
         className={styles.timeSliderInput}
         type="range"
         min={0}
-        max={orderedDates.length - 1}
+        max={maxValue}
         step={1}
-        defaultValue={0}
+        defaultValue={maxValue}
         onChange={(e) =>
           setSelectedReportDate(orderedDates[Number.parseInt(e.target.value)])
         }

--- a/time-travel/DemoWeb/client/app/SalesEvent.ts
+++ b/time-travel/DemoWeb/client/app/SalesEvent.ts
@@ -1,12 +1,8 @@
 export default interface SalesEvent {
-  eventType: string
-  eventId: string
-  timestamp: string
+  eventNumber: string
+  orderId: string
+  at: string
   region: string
   category: string
-  aggregateId: string
-  version: number
-  orderAmount?: number
-  reason?: string
-  quantity?: number
+  totalSalesForCategory: number
 }

--- a/time-travel/DemoWeb/client/package-lock.json
+++ b/time-travel/DemoWeb/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "DemoWeb",
       "version": "0.0.0",
       "dependencies": {
+        "classnames": "^2.5.1",
         "lodash": "^4.17.21",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1124,6 +1125,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",

--- a/time-travel/DemoWeb/client/package.json
+++ b/time-travel/DemoWeb/client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "DemoWeb",
+  "name": "demo-web",
   "private": true,
   "version": "0.0.0",
   "type": "module",
@@ -9,6 +9,7 @@
     "build": "npx vite build"
   },
   "dependencies": {
+    "classnames": "^2.5.1",
     "lodash": "^4.17.21",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/time-travel/DemoWeb/client/package.json
+++ b/time-travel/DemoWeb/client/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "npx vite",
+    "watch": "npx vite build --watch",
     "build": "npx vite build"
   },
   "dependencies": {

--- a/time-travel/DemoWeb/client/tsconfig.json
+++ b/time-travel/DemoWeb/client/tsconfig.json
@@ -15,5 +15,5 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["src"]
+  "include": ["app"]
 }

--- a/time-travel/DemoWeb/client/vite.config.ts
+++ b/time-travel/DemoWeb/client/vite.config.ts
@@ -1,14 +1,19 @@
 import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
 
-import * as path from 'path'
+import * as path from "path"
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  css: {
+    modules: {
+      localsConvention: "camelCase",
+    },
+  },
   build: {
-    outDir: path.resolve(__dirname, '../wwwroot'),
+    outDir: path.resolve(__dirname, "../wwwroot"),
     minify: false,
-    emptyOutDir: true
-  }
+    emptyOutDir: true,
+  },
 })


### PR DESCRIPTION
* Updated client side read model types to reflect new naming
* Added call to retrieve events from the server
  * Events are retrieved when the user selects a Daily Sales or Target Sales cell
  * The event stream section refreshes when the date changes or another table cell is selected
* Fixed arrows for daily sales
* Fixed styling of progress (previously the number would overflow when the progress is low)


https://github.com/user-attachments/assets/6267b2b4-9084-4414-86e3-ca7b5f6d0b26

